### PR TITLE
fix docker image tag

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -39,7 +39,7 @@
                     {
                         "name": "[parameters('ContainerName')]",
                         "properties": {
-                            "image": "jacobalberty/unifi:stable",
+                            "image": "jacobalberty/unifi:latest",
                             "ports": [
                                 {
                                     "protocol": "UDP",


### PR DESCRIPTION
jacobalberty uses latest tag now instead of stable tag
https://hub.docker.com/r/jacobalberty/unifi/tags